### PR TITLE
Add signature verification to / endpoint

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,5 @@
 SENTRY_TOKEN=
+SENTRY_API_SECRET=
 SENTRY_ORG=
 SENTRY_DSN=
 # Test w/ hard-coded project first

--- a/__mocks__/verify.js
+++ b/__mocks__/verify.js
@@ -1,0 +1,1 @@
+module.exports = () => true;

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,8 @@ const sendRequest = require("request-promise-native");
 const { sentryAPIbase } = require("../constants");
 const mockData = require("./mockdata.js");
 
+jest.mock('../verify.js');
+
 describe("app.js", () => {
   let server;
   const app = require("../app");

--- a/__tests__/verify.test.js
+++ b/__tests__/verify.test.js
@@ -1,25 +1,21 @@
 const verifySignature = require("../verify");
 
 describe("verify.js", () => {
-  beforeAll(() => {
-    process.env.SENTRY_API_SECRET = "abc123";
-  });
-
   it("should verify a valid signature", () => {
     expect(verifySignature({
       body: { issue: 123456 },
       headers: {
-        "Sentry-Hook-Signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
+        "sentry-hook-signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
       }
-    })).toBe(true);
+    }, "abc123")).toBe(true);
   });
   
   it("should reject an invalid signature", () => {
     expect(verifySignature({
         body: { issue: 1234567890 },
         headers: {
-          "Sentry-Hook-Signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
+          "sentry-hook-signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
         }
-      })).toBe(false);
+      }, "abc123")).toBe(false);
   });
 });

--- a/__tests__/verify.test.js
+++ b/__tests__/verify.test.js
@@ -1,0 +1,25 @@
+const verifySignature = require("../verify");
+
+describe("verify.js", () => {
+  beforeAll(() => {
+    process.env.SENTRY_API_SECRET = "abc123";
+  });
+
+  it("should verify a valid signature", () => {
+    expect(verifySignature({
+      body: { issue: 123456 },
+      headers: {
+        "Sentry-Hook-Signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
+      }
+    })).toBe(true);
+  });
+  
+  it("should reject an invalid signature", () => {
+    expect(verifySignature({
+        body: { issue: 1234567890 },
+        headers: {
+          "Sentry-Hook-Signature": "0e2041f59516f3d4507b22216f2e0050931692c1ae71c4207d38d79781963dfa"
+        }
+      })).toBe(false);
+  });
+});

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ app.queuedUsers = [];
 
 // When receiving a POST request from Sentry:
 app.post("/", async function(request, response) {
-  if (!verifySignature(request)) {
+  if (!verifySignature(request, process.env.SENTRY_API_SECRET)) {
     return response.status(401).send('bad signature');
   }
 

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const { projectID, orgSlug } = require("./constants");
 const { getProjectUsers, assignIssue } = require("./apiRequests");
+const verifySignature = require("./verify");
 
 const http = require("http");
 const express = require("express");
@@ -13,8 +14,13 @@ app.allUsers = [];
 // Array of usernames queued up to be assigned to upcoming new issues
 app.queuedUsers = [];
 
+
 // When receiving a POST request from Sentry:
 app.post("/", async function(request, response) {
+  if (!verifySignature(request)) {
+    return response.status(401).send('bad signature');
+  }
+
   const resource = request.get("sentry-hook-resource");
   const action = request.body.action;
 

--- a/verify.js
+++ b/verify.js
@@ -5,7 +5,6 @@ function verifySignature(request, secret='') {
   const hmac = crypto.createHmac("sha256", secret);
   hmac.update(JSON.stringify(request.body), 'utf8');
   const digest = hmac.digest('hex');
-  console.log(digest);
   return digest === request.headers["sentry-hook-signature"];
 }
 

--- a/verify.js
+++ b/verify.js
@@ -3,8 +3,8 @@ const crypto = require('crypto');
 function verifySignature(request) {
   // See: https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature
   const hmac = crypto.createHmac("sha256", process.env.SENTRY_API_SECRET);
-  const expected = hmac.update(JSON.stringify(request.body));
-  return hmac.digest() === request.headers["Sentry-Hook-Signature"];
+  const expected = hmac.update(JSON.stringify(request.body), 'utf8');
+  return hmac.digest('hex') === request.headers["Sentry-Hook-Signature"];
 }
 
 module.exports = verifySignature;

--- a/verify.js
+++ b/verify.js
@@ -3,8 +3,9 @@ const crypto = require('crypto');
 function verifySignature(request) {
   // See: https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature
   const hmac = crypto.createHmac("sha256", process.env.SENTRY_API_SECRET);
-  const expected = hmac.update(JSON.stringify(request.body), 'utf8');
-  return hmac.digest('hex') === request.headers["Sentry-Hook-Signature"];
+  hmac.update(JSON.stringify(request.body), 'utf8');
+  const digest = hmac.digest('hex');
+  return hmac.digest('hex') === request.headers["sentry-hook-signature"];
 }
 
 module.exports = verifySignature;

--- a/verify.js
+++ b/verify.js
@@ -1,10 +1,11 @@
 const crypto = require('crypto');
 
-function verifySignature(request) {
+function verifySignature(request, secret='') {
   // See: https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature
-  const hmac = crypto.createHmac("sha256", process.env.SENTRY_API_SECRET);
+  const hmac = crypto.createHmac("sha256", secret);
   hmac.update(JSON.stringify(request.body), 'utf8');
   const digest = hmac.digest('hex');
+  console.log(digest);
   return digest === request.headers["sentry-hook-signature"];
 }
 

--- a/verify.js
+++ b/verify.js
@@ -1,0 +1,10 @@
+const crypto = require('crypto');
+
+function verifySignature(request) {
+  // See: https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature
+  const hmac = crypto.createHmac("sha256", process.env.SENTRY_API_SECRET);
+  const expected = hmac.update(JSON.stringify(request.body));
+  return hmac.digest() === request.headers["Sentry-Hook-Signature"];
+}
+
+module.exports = verifySignature;

--- a/verify.js
+++ b/verify.js
@@ -5,7 +5,7 @@ function verifySignature(request) {
   const hmac = crypto.createHmac("sha256", process.env.SENTRY_API_SECRET);
   hmac.update(JSON.stringify(request.body), 'utf8');
   const digest = hmac.digest('hex');
-  return hmac.digest('hex') === request.headers["sentry-hook-signature"];
+  return digest === request.headers["sentry-hook-signature"];
 }
 
 module.exports = verifySignature;


### PR DESCRIPTION
Implementing this check to verify that webhook POST requests from Sentry are genuine: https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature

Note: I haven't actually verified this verification works. @LearningNerd since you have an end-to-end testing environment working, can you try this out?