### PR TITLE
Add test that demonstrates infinite loop ...

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,6 +71,7 @@ async function assignNextUser(issueID) {
 }
 
 async function repopulateUserQueue() {
+  console.warn('REPOPULATE');
   // If no valid users are remaining in the queue, request updated user list
   if (app.allUsers.length === 0) {
     let updatedUsers = await getProjectUsers(projectID, orgSlug);


### PR DESCRIPTION
It's possible to get into a state where, if the user queue empties, simultaneous webhook POSTs from Sentry will trigger sentry-round-robin into an infinite loop.

The attached test case demonstrates how to trigger this scenario.

I think that, in order to solve this, we either need to lock the state of the app while refetching users, or instead reconsider the whole refetching behavior entirely.