### PR TITLE
Don't refetch users if master list empty

### DIFF
--- a/__tests__/apiRequests.test.js
+++ b/__tests__/apiRequests.test.js
@@ -24,16 +24,16 @@ describe("getProjectUsers ", () => {
     expect(res).toHaveLength(2);
   });
 
-  test("fails with empty array", async () => {
+  test("throws an error on failure", async () => {
     nock(sentryAPIbase)
       .get(
         `/organizations/${mockData.orgSlug}/users/?project=${mockData.projectID}`
       )
       .reply(404, { detail: "The requested resource does not exist" });
 
-    const res = await getProjectUsers(mockData.projectID, mockData.orgSlug);
-    expect(res).toHaveLength(0);
+    await expect(getProjectUsers(mockData.projectID, mockData.orgSlug)).rejects.toThrow();
   });
+
 });
 
 describe("assignIssue ", () => {

--- a/__tests__/apiRequests.test.js
+++ b/__tests__/apiRequests.test.js
@@ -37,7 +37,7 @@ describe("getProjectUsers ", () => {
 });
 
 describe("assignIssue ", () => {
-  test("succeeds with status 200 and ...", async () => {
+  test("succeeds with response body containing issueID and username", async () => {
     nock(sentryAPIbase)
       .put(`/issues/${mockData.issueID}/`, {
         assignedTo: mockData.userNames[0]
@@ -50,7 +50,7 @@ describe("assignIssue ", () => {
     expect(res.assignedTo.email).toBe(mockData.userNames[0]);
   });
 
-  test(" where user doesnt exist fails with status code for no user", async () => {
+  test(" throws error if user is unknown", async () => {
     nock(sentryAPIbase)
       .put(`/issues/${mockData.issueID}/`, {
         assignedTo: mockData.userNames[0]
@@ -59,7 +59,8 @@ describe("assignIssue ", () => {
         assignedTo: ["Unknown actor input"]
       });
 
-    const res = await assignIssue(mockData.issueID, mockData.userNames[0]);
-    expect(res).toBe(mockData.noUserStatusCode);
+    await expect(assignIssue(mockData.issueID, mockData.userNames[0])).rejects.toThrow();
+    // const res = await assignIssue(mockData.issueID, mockData.userNames[0]);
+    // expect(res).toBe(mockData.noUserStatusCode);
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -37,8 +37,9 @@ describe("app.js", () => {
   });
 
   beforeEach(() => {
+    // Reset state between tests, as if server has been restarted each time
     app.allUsers = [...mockData.userNames];
-    app.queuedUsers = [...mockData.userNames];
+    app.nextUserIndex = 0;
 
     // Mock request for fetching users; persist between tests
     nock(sentryAPIbase)
@@ -70,10 +71,14 @@ describe("app.js", () => {
     expect(result).toBe("ok");
   });
 
-  test("First user is assigned to an issue and removed from queue", async function() {
-    // Start with array of user #1 and user #2
-    expect(app.queuedUsers.length).toBe(2);
-    expect(app.queuedUsers[0]).toBe(mockData.userNames[0]);
+  test("First user is assigned to an issue and next user index advances", async function() {
+    // Start with array of user #1 and user #2; user #1 is next to be assigned
+    expect(app.allUsers.length).toBe(2);
+    expect(app.nextUserIndex).toBe(0);
+    expect(app.allUsers[app.nextUserIndex]).toBe(mockData.userNames[0]);
+
+    console.log(app.nextUserIndex, app.allUsers);
+    console.log(app.allUsers[app.nextUserIndex]);
 
     // Assign issue to mock user 1
     const request = nock(sentryAPIbase)
@@ -85,12 +90,17 @@ describe("app.js", () => {
     await sendRequest(newIssueRequestOptions);
     expect(request.isDone()).toBe(true);
 
-    // Expect user #1 to be removed, so user at index 0 is now user #2
-    expect(app.queuedUsers.length).toBe(1);
-    expect(app.queuedUsers[0]).toBe(mockData.userNames[1]);
+    // Expect next user to be user #2
+    expect(app.nextUserIndex).toBe(1);
+    expect(app.allUsers[app.nextUserIndex]).toBe(mockData.userNames[1]);
   });
 
-  test("When all users in queue are assigned an issue, queue is reset", async function() {
+  test("When all users have been assigned an issue, wrap around to restart the cycle", async function() {
+    // Start with array of user #1 and user #2; user #1 is next to be assigned
+    expect(app.allUsers.length).toBe(2);
+    expect(app.nextUserIndex).toBe(0);
+    expect(app.allUsers[app.nextUserIndex]).toBe(mockData.userNames[0]);
+
     const request1 = nock(sentryAPIbase)
       .put(`/issues/${mockData.issueID}/`, {
         assignedTo: mockData.userNames[0]
@@ -103,17 +113,18 @@ describe("app.js", () => {
       })
       .reply(200, mockData.assignIssueResponse(mockData.userNames[1]));
 
-    // Assign both mock users to issues, removing them form users queue
+    // Assign both mock users to issues
     await sendRequest(newIssueRequestOptions);
     expect(request1.isDone()).toBe(true);
 
     await sendRequest(newIssueRequestOptions);
     expect(request2.isDone()).toBe(true);
 
-    // Expect queue to be empty
-    expect(app.queuedUsers.length).toBe(0);
+    // Expect next user to be user #1 again (wrap around)
+    expect(app.nextUserIndex).toBe(0);
+    expect(app.allUsers[app.nextUserIndex]).toBe(mockData.userNames[0]);
 
-    // Assign a third mock  user, prompting queue to be reset
+    // Assign a third mock issue to the next user
     const request3 = nock(sentryAPIbase)
       .put(`/issues/${mockData.issueID}/`, {
         assignedTo: mockData.userNames[0]
@@ -123,13 +134,14 @@ describe("app.js", () => {
     await sendRequest(newIssueRequestOptions);
     expect(request3.isDone()).toBe(true);
 
-    // User #1 immediately assigned and removed from queue,
-    // so user at index 0 is now user #2
-    expect(app.queuedUsers.length).toBe(1);
-    expect(app.queuedUsers[0]).toBe(mockData.userNames[1]);
+    // Expect next user to be user #2
+    expect(app.nextUserIndex).toBe(1);
+    expect(app.allUsers[app.nextUserIndex]).toBe(mockData.userNames[1]);
   });
 
   test("When a user no longer exists, reassign to subsequent users until successful", async function() {
+
+
     // Response for non-existent user
     const request1 = nock(sentryAPIbase)
       .put(`/issues/${mockData.issueID}/`, { assignedTo: mockData.fakeUser })
@@ -144,23 +156,26 @@ describe("app.js", () => {
 
     // Override with mock user that doesn't exist in the mock API
     app.allUsers[0] = mockData.fakeUser;
-    app.queuedUsers[0] = mockData.fakeUser;
+
+    // Start with array of 2 users, and user 1 is next to be assigned
+    expect(app.allUsers.length).toBe(2);
+    expect(app.nextUserIndex).toBe(0);
 
     // Assign both mock users to issues, removing them form users queue
     await sendRequest(newIssueRequestOptions);
     expect(request1.isDone()).toBe(true); // 400
     expect(request2.isDone()).toBe(true); // 200 (success)
 
-    // Expect queue to be empty after removing nonexistent user #1
-    // and then assigning/removing user #2
-    expect(app.queuedUsers.length).toBe(0);
+    // Expect nonexistent user to be removed from allUsers 
+    // and app.nextUserIndex should NOT have advanced
+    expect(app.allUsers.length).toBe(1);
+    expect(app.nextUserIndex).toBe(0);
   });
 
   // TODO: How to test this?
   test.skip("Upon assigning an issue when no valid users are remaining in allUsers queue, throw error (kill the server)", async function() {
     // Override with empty users queue
     app.allUsers = [];
-    app.queuedUsers = [];
 
     // Response for second (valid) user
     const request = nock(sentryAPIbase)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -156,7 +156,8 @@ describe("app.js", () => {
     expect(app.queuedUsers.length).toBe(0);
   });
 
-  test("Upon assigning an issue when no valid users are remaining in allUsers queue, request new list of users and reassign", async function() {
+  // TODO: How to test this?
+  test.skip("Upon assigning an issue when no valid users are remaining in allUsers queue, throw error (kill the server)", async function() {
     // Override with empty users queue
     app.allUsers = [];
     app.queuedUsers = [];
@@ -169,11 +170,8 @@ describe("app.js", () => {
       .reply(200, mockData.assignIssueResponse(mockData.userNames[0]));
 
     // Create mocked new issue, triggering update of user queue
-    await sendRequest(newIssueRequestOptions);
-    expect(request.isDone()).toBe(true);
-
-    // expect(request2.isDone()).toBe(true);
-    expect(app.queuedUsers.length).toBe(1);
+    await expect(sendRequest(newIssueRequestOptions)).rejects.toThrow();
+    // NOTE: ^ doesn't work of course
   });
 
   describe("no-ops", function () {
@@ -184,7 +182,6 @@ describe("app.js", () => {
         .put(`/issues/${mockData.issueID}/`)
         .query(true)
         .replyWithError('should never be called')
-
     });
 
     it("Should ignore webhook requests for non-issue resources", async function () {

--- a/apiRequests.js
+++ b/apiRequests.js
@@ -9,14 +9,7 @@ async function getProjectUsers(projectID, orgSlug) {
     headers: { Authorization: "Bearer " + process.env.SENTRY_TOKEN }
   };
 
-  let result;
-  try {
-    result = await sendRequest(requestOptions);
-  } catch (error) {
-    console.log("Error retrieving project users: ", error.message);
-    return [];
-  }
-
+  let result = await sendRequest(requestOptions);
   return result.map(userData => userData.user.username);
 }
 

--- a/apiRequests.js
+++ b/apiRequests.js
@@ -25,20 +25,12 @@ async function assignIssue(issueID, username) {
   const requestOptions = {
     url: `${sentryAPIbase}/issues/${issueID}/`,
     method: "PUT",
-
     json: true,
     headers: { Authorization: "Bearer " + process.env.SENTRY_TOKEN },
     body: { assignedTo: username }
   };
 
-  let result;
-  try {
-    result = await sendRequest(requestOptions);
-  } catch (error) {
-    console.log("Error assigning issue: ", error.message);
-    return error.statusCode;
-  }
-  return result;
+  return await sendRequest(requestOptions);
 }
 
 module.exports = {

--- a/app.js
+++ b/app.js
@@ -44,7 +44,6 @@ async function init() {
 
   // Init queue and master list
   app.allUsers = [...updatedUsers];
-  app.queuedUsers = [...updatedUsers];
 }
 
 async function assignNextUser(issueID) {

--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ app.post("/", async function(request, response) {
   }
 
   const resource = request.get("sentry-hook-resource");
-  const action = request.body.action;
+  const {action} = request.body;
 
   // If a new issue was just created
   if (resource === "issue" && action === "created") {
@@ -33,7 +33,7 @@ app.post("/", async function(request, response) {
     }
 
     // Assign issue to the next user in the queue and remove user from queue
-    const issueID = request.body.data.issue.id;
+    const {id:issueID} = request.body.data.issue;
     await assignNextUser(issueID);
   }
 

--- a/app.js
+++ b/app.js
@@ -9,12 +9,15 @@ const bodyParser = require("body-parser");
 
 app.use(bodyParser.json());
 
+app.use(function onError(err, req, res, next) {
+  res.sendStatus(500);
+});
+
 // Array of all usernames with access to the given project
 app.allUsers = [];
 
 // Array of usernames queued up to be assigned to upcoming new issues
 app.queuedUsers = [];
-
 
 // When receiving a POST request from Sentry:
 app.post("/", async function(request, response) {


### PR DESCRIPTION
Changes:
- Throw an error and just stop everything if no valid users are left in `allUsers`
- Now `assignIssue()` in `apiRequests.js` just returns its result, and `assignNextUser()` in `app.js` does the try/catch
- Added another case to check for: if the attempt to assign an issue fails with a code other than 400, throw an error. (But if it fails with code 400, try assigning the issue to the next user in the queue.)

Todo:
- `__tests__/app.test.js` - skipped 1 test; how to test that an error is thrown?
- Suggestions for which other scenarios we should add tests for? 