### PR TITLE
Fix issue 11: Only assign  issues from the specified project

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -213,5 +213,21 @@ describe("app.js", () => {
       expect(result).toBe("ok");
       expect(request.isDone()).toBe(false); // API never called
     });
+
+    it("Should ignore webhook requests for issues that don't belong to the project specified in env", async function () {
+      let result = await sendRequest({
+        url: `http://127.0.0.1:${process.env.PORT}`,
+        method: "POST",
+        json: true,
+        headers: {
+          Authorization: "Bearer " + process.env.SENTRY_TOKEN,
+          "Sentry-Hook-Resource": "issue"
+        },
+        body: mockData.wrongProjectNewIssueRequestBody
+      });
+      expect(result).toBe("ok");
+      expect(request.isDone()).toBe(false); // API never called
+    });
+
   });
 });

--- a/__tests__/mockdata.js
+++ b/__tests__/mockdata.js
@@ -6,10 +6,26 @@ const projectID = "123456";
 
 // Sample Sentry data for API requests
 const issueID = "987654";
+const wrongProjectID = "332211";
 const userNames = ["testEmail@test.com", "otherTestEmail@test.com"];
 const newIssueRequestBody = {
   action: "created",
-  data: { issue: { id: issueID } }
+  data: {
+    issue: {
+      id: issueID,
+      project: {id: projectID}
+    }
+  }
+};
+
+const wrongProjectNewIssueRequestBody = {
+  action: "created",
+  data: {
+    issue: {
+      id: issueID,
+      project: {id: wrongProjectID}
+    }
+  }
 };
 
 // Sentry API sample response for unknown user or user without permissions:
@@ -137,9 +153,11 @@ module.exports = {
   sentryToken,
   orgSlug,
   projectID,
+  wrongProjectID,
   issueID,
   userNames,
   newIssueRequestBody,
+  wrongProjectNewIssueRequestBody,
   getUsersResponse,
   assignIssueResponse,
   getFakeUserResponse,

--- a/app.js
+++ b/app.js
@@ -39,20 +39,25 @@ app.post("/", async function(request, response) {
 
   // If a new issue was just created
   if (resource === "issue" && action === "created") {
-    // Init or reset queue if empty
-    if (app.queuedUsers.length === 0) {
-      app.queuedUsers = [...app.allUsers];
-    }
 
-    // Assign issue to the next user in the queue and remove user from queue
-    const {id:issueID} = request.body.data.issue;
-    await assignNextUser(issueID);
-
-    if (sentry) {
-      sentry.addBreadcrumb({
-        message: `New issue created. issueID: ${issueID}`,
-        level: sentry.Severity.Info
-      });
+    const {id:newIssueProjectID} = request.body.data.issue.project;
+    // Only continue if this issue is for the project specified in .env
+    if (newIssueProjectID === projectID) {
+      // Init or reset queue if empty
+      if (app.queuedUsers.length === 0) {
+        app.queuedUsers = [...app.allUsers];
+      }
+  
+      // Assign issue to the next user in the queue and remove user from queue
+      const {id:issueID} = request.body.data.issue;
+      await assignNextUser(issueID);
+  
+      if (sentry) {
+        sentry.addBreadcrumb({
+          message: `New issue created. issueID: ${issueID}`,
+          level: sentry.Severity.Info
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #11 so now issues are only assigned if they belong to the specified project. Thanks @nolachen, good catch! Also added a test for this.