### PR TITLE
[See PR #15 instead] Create main.yml -- Github Actions to deploy to Heroku

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Deploy to Heroku
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+   runs-on: ubuntu-latest
+   env:
+     HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+   steps: 
+    # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
+    - uses: actions/checkout@v1.0.0
+    - name: Install dependencies, build, and deploy
+      run: |
+        npm install
+        git push https://heroku:$HEROKU_API_KEY@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git HEAD:master


### PR DESCRIPTION
One problem: Sentry can't run Github Actions because we're on a legacy plan. So I forked this repo to https://github.com/LearningNerd/sentry-round-robin and can run it from there.

Thanks @billyvg for your help debugging the Heroku CLI stuff!

To test this out yourself, I think you'll need to fork this repo, and then make a Heroku account and app linked to the repo. 

And the next steps would be:
1. Install the heroku CLI and log in
2. Generate a token with `heroku auth:token`
3. Go to the Github settings page > Secrets and copy that token into a secret with the name `HEROKU_API_KEY`.
4. Make another Github secret named `HEROKU_APP_NAME` that contains the name of your Heroku app (as in `myappname.herokuapp.com`).